### PR TITLE
Pin matplotlib in the default environment too

### DIFF
--- a/python3_rhel7_env.yml
+++ b/python3_rhel7_env.yml
@@ -40,7 +40,7 @@ dependencies:
   - lume-epics
   - lume-impact
   - lume-model
-  - matplotlib
+  - matplotlib<3.9
   - mkdocs
   - mkdocstrings
   - mkdocs-material


### PR DESCRIPTION
This is the quickest way to prevent it pulling in qt6 imports that cause the following issue, can be revisited later
```

INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/_pytest/main.py", line 279, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/_pytest/config/__init__.py", line 1118, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pluggy/_hooks.py", line 535, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pluggy/_callers.py", line 103, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pytestqt/plugin.py", line 243, in pytest_configure
INTERNALERROR>     qt_api.set_qt_api(config.getini("qt_api"))
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pytestqt/qt_compat.py", line 109, in set_qt_api
INTERNALERROR>     self.QtGui = _import_module("QtGui")
INTERNALERROR>   File "/tmp/rhel7_devel/lib/python3.10/site-packages/pytestqt/qt_compat.py", line 105, in _import_module
INTERNALERROR>     m = __import__(_root_module, globals(), locals(), [module_name], 0)
INTERNALERROR> ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
```