### PR TITLE
Add libpython-static to the default environment

### DIFF
--- a/python3_rhel7_env.yml
+++ b/python3_rhel7_env.yml
@@ -38,6 +38,7 @@ dependencies:
   - jupyterlab
   - kafka-python
   - keras
+  - libpython-static
   - lume-epics
   - lume-impact
   - lume-model


### PR DESCRIPTION
Generates the libpythonX.Y.a static python library for the environment under lib/