### PR TITLE
Add cython to various environments

### DIFF
--- a/py312_rhel7_devel.yml
+++ b/py312_rhel7_devel.yml
@@ -11,6 +11,7 @@ dependencies:
   - botorch
   - caproto
   - cx_oracle
+  - cython
   - dask
   - dateparser
   - deap

--- a/python3_devel.yml
+++ b/python3_devel.yml
@@ -12,6 +12,7 @@ dependencies:
   - conda-pack
   - cothread
   - cx_oracle
+  - cython
   - dask
   - dateparser
   - deap

--- a/python3_rhel7_env.yml
+++ b/python3_rhel7_env.yml
@@ -11,6 +11,7 @@ dependencies:
   - botorch
   - caproto
   - cx_oracle
+  - cython
   - dask
   - dateparser
   - deap

--- a/rhel7_devel.yml
+++ b/rhel7_devel.yml
@@ -10,6 +10,7 @@ dependencies:
   - botorch
   - caproto
   - cx_oracle
+  - cython
   - dask
   - dateparser
   - deap


### PR DESCRIPTION
This was apparently removed in a bulk cleanup a while back. This is handy for building certain packages (CPSW, p4p)