### PR TITLE
Add additional SLAC repositories to rhel7_devel.yml dependencies

### DIFF
--- a/rhel7_devel.yml
+++ b/rhel7_devel.yml
@@ -123,7 +123,13 @@ dependencies:
     - git+https://github.com/lume-science/lume-torch
     - git+https://github.com/lume-science/lume-pva
     - git+https://github.com/pyro-ppl/pyro.git  # Latest release (1.9.1) isn't python 3.12 compatible so install from latest source which is
+    - git+https://github.com/slaclab/slac-db
+    - git+https://github.com/slaclab/slac-devices
+    - git+https://github.com/slaclab/slac-measurements
+    - git+https://github.com/slaclab/slac-timing
+    - git+https://github.com/slaclab/slac-tools
     - git+https://github.com/slaclab/slacepics
+    - git+https://github.com/slaclab/slacwire
     - git+https://github.com/slaclab/subprocessca
     - git+https://github.com/slaclab/virtual-accelerator.git
 #


### PR DESCRIPTION
This pull request adds several new SLAC-related repositories to the list of development dependencies in the `rhel7_devel.yml` file. These additions will ensure that the development environment includes the latest tools and libraries from the slac-tools ecosystem.

Dependency additions:

* Added the following SLAC repositories as dependencies: `slac-db`, `slac-devices`, `slac-measurements`, `slac-timing`, `slac-tools`, and `slacwire` to the `dependencies` section of `rhel7_devel.yml`.